### PR TITLE
Improve error handling

### DIFF
--- a/components/jtl-splitter/src/main/java/org/wso2/performance/common/jtl/splitter/JTLSplitter.java
+++ b/components/jtl-splitter/src/main/java/org/wso2/performance/common/jtl/splitter/JTLSplitter.java
@@ -133,7 +133,8 @@ public final class JTLSplitter {
                 standardOutput.print("Started splitting...\r");
             }
 
-            final int columnLimit = 16;
+            // Support JMeter 5.0
+            final int columnLimit = 17;
 
             lineLoop:
             while ((line = br.readLine()) != null) {
@@ -145,8 +146,7 @@ public final class JTLSplitter {
                         values[i++] = line.substring(pos, end);
                         pos = end + 1;
                     } else {
-                        // Validate line
-                        // JTL file usually has 16 columns
+                        // Validate number of columns
                         errorOutput.format("Line %d has more columns than expected: %s%n", lineNumber, line);
                         continue lineLoop;
                     }

--- a/distribution/scripts/jmeter/install-jmeter.sh
+++ b/distribution/scripts/jmeter/install-jmeter.sh
@@ -72,15 +72,20 @@ if [ "$download" = true ]; then
         echo "Do not specify JMeter distribution file with download option."
         exit 1
     fi
-    jmeter_dist="apache-jmeter-4.0.tgz"
+    jmeter_version="4.0"
+    jmeter_dist="apache-jmeter-${jmeter_version}.tgz"
+    jmeter_download_url="https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${jmeter_version}.tgz"
     if [[ ! -f $jmeter_dist ]]; then
         # Download JMeter
         echo "Downloading JMeter distribution"
-        wget -q http://www-us.apache.org/dist//jmeter/binaries/apache-jmeter-4.0.tgz -O $jmeter_dist
+        if ! wget -q $jmeter_download_url -O $jmeter_dist; then
+            echo "Failed to download JMeter!"
+            exit 1
+        fi
     fi
     # Verify JMeter
     echo "Verifying JMeter distribution"
-    curl -s http://www-us.apache.org/dist//jmeter/binaries/apache-jmeter-4.0.tgz.sha512 | sha512sum -c
+    curl -s ${jmeter_download_url}.sha512 | sha512sum -c
 fi
 
 if [[ ! -f $jmeter_dist ]]; then

--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,7 @@
         <testng.version>6.14.3</testng.version>
         <gson.version>2.8.5</gson.version>
         <hdrhistogram.version>2.1.10</hdrhistogram.version>
-        <jmeter.version>4.0</jmeter.version>
+        <jmeter.version>5.0</jmeter.version>
         <commons.lang3.version>3.8</commons.lang3.version>
         <!-- Maven Plugins -->
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>


### PR DESCRIPTION
## Purpose
- Fix JMeter download issue. When JMeter 5.0 was released, JMeter 4.0 link returned 404.
- Fix Payload Generation
- Support JMeter 5.0 in JTL Splitter. JMeter 5.0 JTL has 17 columns.

## Goals
- Download JMeter from archives