### PR TITLE
Add common AWS CloudFormation template

### DIFF
--- a/distribution/scripts/cloudformation/create-template.py
+++ b/distribution/scripts/cloudformation/create-template.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018, WSO2 Inc. (http://wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# ----------------------------------------------------------------------------
+# Create AWS CloudFormation template
+# ----------------------------------------------------------------------------
+
+import argparse
+import csv
+import json
+import os
+from jinja2 import Environment, FileSystemLoader
+
+PATH = os.path.dirname(os.path.abspath(__file__))
+TEMPLATE_ENVIRONMENT = Environment(
+    autoescape=False,
+    loader=FileSystemLoader(os.path.join(PATH, 'templates')),
+    trim_blocks=False,
+    keep_trailing_newline=True)
+
+
+def render_template(template_filename, context):
+    return TEMPLATE_ENVIRONMENT.get_template(template_filename).render(context)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Create AWS CloudFormation template.')
+    parser.add_argument('--template-name', required=True, help='The template file name.', type=str)
+    parser.add_argument('--jmeter-servers', required=True, help='Number of JMeter Servers.', type=int)
+    parser.add_argument('--output-name', required=True, help='Output file name.', type=str)
+
+    args = parser.parse_args()
+
+    context = {'jmeter_servers': args.jmeter_servers}
+
+    with open(args.output_name, 'w') as f:
+        markdown_file = render_template(args.template_name, context)
+        f.write(markdown_file.encode("utf-8"))
+
+
+if __name__ == "__main__":
+    main()

--- a/distribution/scripts/cloudformation/create-template.py
+++ b/distribution/scripts/cloudformation/create-template.py
@@ -46,7 +46,7 @@ def main():
 
     args = parser.parse_args()
 
-    context = {'jmeter_servers': args.jmeter_servers}
+    context = {'jmeter_servers': args.jmeter_servers, 'start_bastian': True}
 
     with open(args.output_name, 'w') as f:
         markdown_file = render_template(args.template_name, context)

--- a/distribution/scripts/cloudformation/templates/common_perf_test_cfn.yaml
+++ b/distribution/scripts/cloudformation/templates/common_perf_test_cfn.yaml
@@ -298,7 +298,7 @@ Resources:
   #######################
   # EC2 Instances
   #######################
-{%- macro ec2instance(resource_name, name, instance_type_ref=None, files=[], public=false, volume_size=None) %}
+{%- macro ec2instance(resource_name, name, instance_type_ref, files=[], public=false, volume_size=None) %}
   {{ resource_name }}:
     Type: 'AWS::EC2::Instance'
     DependsOn: [AttachGateway, BucketPolicy]
@@ -459,12 +459,12 @@ Resources:
           mkdir aws-cfn-bootstrap-latest
           curl -s https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz -O
           pip install aws-cfn-bootstrap-latest.tar.gz
-          tar xzf aws-cfn-bootstrap-latest.tar.gz -C  aws-cfn-bootstrap-latest --strip-components 1
+          tar xzf aws-cfn-bootstrap-latest.tar.gz -C aws-cfn-bootstrap-latest --strip-components 1
           ln -s aws-cfn-bootstrap-latest/init/ubuntu/cfn-hup /etc/init.d/cfn-hup
           # Initialize
           /usr/local/bin/cfn-init -v --stack ${AWS::StackId} --resource {{ resource_name }} --region ${AWS::Region}
           # Extract distribution
-          tar -xvf /home/ubuntu/performance-distribution.tar.gz -C /home/ubuntu
+          tar xzf /home/ubuntu/performance-distribution.tar.gz -C /home/ubuntu
           # Must run setup script in User Data (Commands executed within cfn-init do not show the progress in logs)
           # Run setup
           {% if caller is defined -%}
@@ -478,6 +478,67 @@ Resources:
 {%- endmacro %}
 {% block ec2instances %}
 {% endblock %}
+{% if start_bastian %}
+  BastionInstance:
+    Type: 'AWS::EC2::Instance'
+    Metadata:
+      'AWS::CloudFormation::Init':
+        config:
+          files:
+            /home/ubuntu/performance-distribution.tar.gz:
+              source: !Join
+                - ''
+                - - 'https://s3.'
+                  - !Ref BucketRegion
+                  - '.amazonaws.com/'
+                  - !Ref BucketName
+                  - /
+                  - !Ref PerformanceDistributionName
+                  - .pem
+              mode: '000664'
+              owner: ubuntu
+              group: ubuntu
+              authentication: "S3AccessCreds"
+            /home/ubuntu/private_key.pem:
+              source: !Join
+                - ''
+                - - 'https://s3.'
+                  - !Ref BucketRegion
+                  - '.amazonaws.com/'
+                  - !Ref BucketName
+                  - /
+                  - !Ref KeyName
+                  - .pem
+              mode: '000400'
+              owner: ubuntu
+              group: ubuntu
+              authentication: "S3AccessCreds"
+      'AWS::CloudFormation::Authentication':
+        S3AccessCreds:
+          type: S3
+          accessKeyId: !Ref CfnKeys
+          secretKey: !GetAtt
+            - CfnKeys
+            - SecretAccessKey
+          buckets:
+            - !Ref BucketName
+    Properties:
+      ImageId: !FindInMap [ AWSRegion2AMI, !Ref "AWS::Region", AMI ]
+      InstanceType: t3.nano
+      Tags:
+        - Key: Name
+          Value: !Join
+              - ':'
+              - - 'bastian'
+                - !Ref TestName
+      NetworkInterfaces:
+        - GroupSet:
+            - !Ref InstanceSecurityGroup
+          AssociatePublicIpAddress: 'true'
+          SubnetId: !Ref PublicSubnet
+          DeviceIndex: '0'
+          DeleteOnTermination: 'true'
+{% endif -%}
 Outputs:
 {%- block outputs %}
   StackVPC:

--- a/distribution/scripts/cloudformation/templates/common_perf_test_cfn.yaml
+++ b/distribution/scripts/cloudformation/templates/common_perf_test_cfn.yaml
@@ -525,6 +525,7 @@ Resources:
     Properties:
       ImageId: !FindInMap [ AWSRegion2AMI, !Ref "AWS::Region", AMI ]
       InstanceType: t3.nano
+      KeyName: !Ref KeyName
       Tags:
         - Key: Name
           Value: !Join

--- a/distribution/scripts/cloudformation/templates/common_perf_test_cfn.yaml
+++ b/distribution/scripts/cloudformation/templates/common_perf_test_cfn.yaml
@@ -1,0 +1,486 @@
+# ----------------------------------------------------------------------------
+#
+# Copyright (c) 2018, WSO2 Inc. (http://wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# ----------------------------------------------------------------------------
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  AWS CloudFormation Template to run performance tests. This template
+  creates Amazon EC2 instances in a VPC. The JMeter Client EC2 instance will be in a
+  public subnet with a public IP. All other EC2 instances will be in a private subnet.
+  **WARNING** This template creates multiple Amazon AWS resources. You will be
+  billed for the AWS resources used if you create a stack from this template.
+##############################################################################################
+# Mappings for Ubuntu AMIs.
+# Refer https://cloud-images.ubuntu.com/locator/ec2/ for ubuntu AMI-ID's for the LTS version
+# Search using "bionic us- hvm:ebs-ssd amd64"
+##############################################################################################
+Mappings:
+  AWSRegion2AMI:
+    us-east-1:
+      AMI: ami-0d2505740b82f7948
+    us-east-2:
+      AMI: ami-0cf8cc36b8c81c6de
+    us-west-1:
+      AMI: ami-09c5eca75eed8245a
+    us-west-2:
+      AMI: ami-0f05ad41860678734
+#############################
+# User inputs
+#############################
+Parameters:
+  KeyName:
+    Description: Name of an existing EC2 KeyPair to enable SSH access to the instance
+    Type: 'AWS::EC2::KeyPair::KeyName'
+    ConstraintDescription: must be the name of an existing EC2 KeyPair.
+  TestName:
+    Description: Name of the tests
+    Type: String
+  BucketName:
+    Description: Name of bucket containing files
+    Type: String
+  BucketRegion:
+    Description: The region of the bucket
+    Type: String
+  PerformanceDistributionName:
+    Description: The name of the 'Performance Distribution' package in S3 Bucket.
+    Type: String
+  JMeterDistributionName:
+    Description: The name of the 'Apache JMeter distribution' in S3 Bucket.
+    Type: String
+    ConstraintDescription: must be a valid tgz package
+    AllowedPattern: ^.*\.tgz$
+  OracleJDKDistributionName:
+    Description: The name of the 'Oracle JDK Distribution' in S3 Bucket.
+    Type: String
+    ConstraintDescription: must be a valid Oracle JDK
+    AllowedPattern: ^jdk-8u[0-9]+-linux-x64.tar.gz$
+  JMeterClientInstanceType:
+    Description: JMeter Client EC2 instance type
+    Type: String
+  JMeterServerInstanceType:
+    Description: JMeter Server EC2 instance type
+    Type: String
+  {% block parameters %}{% endblock %}
+################################
+# Create AWS resources
+################################
+Resources:
+  #########################################
+  # Create IAM resources to read S3 bucket
+  #########################################
+  CfnUser:
+    Type: 'AWS::IAM::User'
+    Properties:
+      Path: /
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'cloudformation:DescribeStackResource'
+                  - 's3:GetObject'
+                Resource: '*'
+  CfnKeys:
+    Type: 'AWS::IAM::AccessKey'
+    Properties:
+      UserName: !Ref CfnUser
+  BucketPolicy:
+    Type: 'AWS::S3::BucketPolicy'
+    Properties:
+      PolicyDocument:
+        Version: 2008-10-17
+        Id: MyPolicy
+        Statement:
+          - Sid: ReadAccess
+            Action:
+              - 's3:GetObject'
+            Effect: Allow
+            Resource: !Join
+              - ''
+              - - 'arn:aws:s3:::'
+                - !Ref BucketName
+                - /*
+            Principal:
+              AWS: !GetAtt
+                - CfnUser
+                - Arn
+      Bucket: !Ref BucketName
+  ####################################################################
+  # Create IAM resources to configure AWS Logs Agent in EC2 instances
+  ####################################################################
+  LogRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      Policies:
+        - PolicyName: LogRolePolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'logs:CreateLogGroup'
+                  - 'logs:CreateLogStream'
+                  - 'logs:PutLogEvents'
+                  - 'logs:DescribeLogStreams'
+                Resource: 'arn:aws:logs:*:*:*'
+  LogRoleInstanceProfile:
+    Type: 'AWS::IAM::InstanceProfile'
+    Properties:
+      Path: /
+      Roles:
+        - !Ref LogRole
+  # Logs Group
+  CloudFormationLogs:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName: !Join
+        - '-'
+        - - !Ref AWS::StackName
+          - 'CloudFormationLogs'
+      RetentionInDays: 7
+  ##########################################################################################
+  # Create VPC, public subnet and private subnet
+  # https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Scenario2.html
+  # https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Internet_Gateway.html
+  ##########################################################################################
+  VPC:
+    Type: 'AWS::EC2::VPC'
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: !Join
+            - ':'
+            - - 'VPC'
+              - !Ref TestName
+  # Configure Public Subnet
+  PublicSubnet:
+    Type: 'AWS::EC2::Subnet'
+    Properties:
+      VpcId: !Ref VPC
+      AvailabilityZone: !Select
+        - 0
+        - Fn::GetAZs: !Ref 'AWS::Region'
+      CidrBlock: 10.0.0.0/24
+      Tags:
+        - Key: Name
+          Value: !Join
+            - ':'
+            - - 'PublicSubnet'
+              - !Ref TestName
+  InternetGateway:
+    Type: 'AWS::EC2::InternetGateway'
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Join
+            - ':'
+            - - 'InternetGateway'
+              - !Ref TestName
+  AttachGateway:
+    Type: 'AWS::EC2::VPCGatewayAttachment'
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+  PublicRouteTable:
+    Type: 'AWS::EC2::RouteTable'
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Join
+            - ':'
+            - - 'PublicRouteTable'
+              - !Ref TestName
+  PublicRoute:
+    Type: 'AWS::EC2::Route'
+    DependsOn: AttachGateway
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+  PublicSubnetRouteTableAssociation:
+    Type: 'AWS::EC2::SubnetRouteTableAssociation'
+    Properties:
+      SubnetId: !Ref PublicSubnet
+      RouteTableId: !Ref PublicRouteTable
+  # Configure Private Subnet
+  PrivateSubnet:
+    Type: 'AWS::EC2::Subnet'
+    Properties:
+      VpcId: !Ref VPC
+      AvailabilityZone: !Select
+        - 0
+        - Fn::GetAZs: !Ref 'AWS::Region'
+      CidrBlock: 10.0.1.0/24
+      Tags:
+        - Key: Name
+          Value: !Join
+            - ':'
+            - - 'PrivateSubnet'
+              - !Ref TestName
+  NatGateway:
+    Type: 'AWS::EC2::NatGateway'
+    DependsOn: AttachGateway
+    Properties:
+      AllocationId: !GetAtt
+        - NatGatewayIPAddress
+        - AllocationId
+      SubnetId: !Ref PublicSubnet
+      Tags:
+        - Key: Name
+          Value: !Join
+            - ':'
+            - - 'NatGateway'
+              - !Ref TestName
+  NatGatewayIPAddress:
+    Type: 'AWS::EC2::EIP'
+    DependsOn: AttachGateway
+    Properties:
+      Domain: vpc
+  PrivateRouteTable:
+    Type: 'AWS::EC2::RouteTable'
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Join
+            - ':'
+            - - 'PrivateRouteTable'
+              - !Ref TestName
+  PrivateRoute:
+    Type: 'AWS::EC2::Route'
+    DependsOn: AttachGateway
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref NatGateway
+  PrivateSubnetRouteTableAssociation:
+    Type: 'AWS::EC2::SubnetRouteTableAssociation'
+    Properties:
+      SubnetId: !Ref PrivateSubnet
+      RouteTableId: !Ref PrivateRouteTable
+  InstanceSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      VpcId: !Ref VPC
+      GroupDescription: Security Group for EC2 instances
+      SecurityGroupIngress:
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+  #######################
+  # EC2 Instances
+  #######################
+{%- macro ec2instance(resource_name, name, instance_type_ref=None, files=[], public=false, volume_size=None) %}
+  {{ resource_name }}:
+    Type: 'AWS::EC2::Instance'
+    DependsOn: [AttachGateway, BucketPolicy]
+    Metadata:
+      'AWS::CloudFormation::Init':
+        config:
+          files:
+            /etc/awslogs/awslogs.conf:
+              content: !Sub |
+                [general]
+                state_file = /var/awslogs/state/agent-state
+
+                [/var/log/cloud-init.log]
+                file = /var/log/cloud-init.log
+                log_group_name = ${CloudFormationLogs}
+                log_stream_name = {instance_id}/{{ name }}/cloud-init.log
+                datetime_format = %Y-%m-%d %H:%M:%S
+
+                [/var/log/cloud-init-output.log]
+                file = /var/log/cloud-init-output.log
+                log_group_name = ${CloudFormationLogs}
+                log_stream_name = {instance_id}/{{ name }}/cloud-init-output.log
+                datetime_format =
+
+                [/var/log/cfn-init.log]
+                file = /var/log/cfn-init.log
+                log_group_name = ${CloudFormationLogs}
+                log_stream_name = {instance_id}/{{ name }}/cfn-init.log
+                datetime_format = %Y-%m-%d %H:%M:%S
+
+                [/var/log/cfn-init-cmd.log]
+                file = /var/log/cfn-init-cmd.log
+                log_group_name = ${CloudFormationLogs}
+                log_stream_name = {instance_id}/{{ name }}/cfn-init-cmd.log
+                datetime_format = %Y-%m-%d %H:%M:%S
+
+                [/var/log/cfn-wire.log]
+                file = /var/log/cfn-wire.log
+                log_group_name = ${CloudFormationLogs}
+                log_stream_name = {instance_id}/{{ name }}/cfn-wire.log
+                datetime_format = %Y-%m-%d %H:%M:%S
+
+                [/var/log/syslog]
+                file = /var/log/syslog
+                log_group_name = ${CloudFormationLogs}
+                log_stream_name = {instance_id}/{{ name }}/syslog
+                datetime_format = %b %d %H:%M:%S
+              mode: '000444'
+              owner: root
+              group: root
+            /home/ubuntu/performance-distribution.tar.gz:
+              source: !Join
+                - ''
+                - - 'https://s3.'
+                  - !Ref BucketRegion
+                  - '.amazonaws.com/'
+                  - !Ref BucketName
+                  - /
+                  - !Ref PerformanceDistributionName
+                  - .pem
+              mode: '000664'
+              owner: ubuntu
+              group: ubuntu
+              authentication: "S3AccessCreds"
+            /home/ubuntu/private_key.pem:
+              source: !Join
+                - ''
+                - - 'https://s3.'
+                  - !Ref BucketRegion
+                  - '.amazonaws.com/'
+                  - !Ref BucketName
+                  - /
+                  - !Ref KeyName
+                  - .pem
+              mode: '000400'
+              owner: ubuntu
+              group: ubuntu
+              authentication: "S3AccessCreds"
+            {%- for file in files %}
+            /home/ubuntu/{{ file['name'] }}:
+              source: !Join
+                - ''
+                - - 'https://s3.'
+                  - !Ref BucketRegion
+                  - '.amazonaws.com/'
+                  - !Ref BucketName
+                  - /
+                  - !Ref {{ file['ref'] }}
+              mode: '000664'
+              owner: ubuntu
+              group: ubuntu
+              authentication: "S3AccessCreds"
+            {%- endfor %}
+          commands:
+            01_create_state_directory:
+              command: mkdir -p /var/awslogs/state
+            02_download_awslogs_agent:
+              command: curl -s https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py -O
+              cwd: /root
+            03_change_permission:
+              command: chmod +x ./awslogs-agent-setup.py
+              cwd: /root
+            04_install_awslogs_agent:
+              command: !Join
+                - ''
+                - - './awslogs-agent-setup.py -n -r '
+                  - !Ref 'AWS::Region'
+                  - ' -c /etc/awslogs/awslogs.conf'
+              cwd: /root
+      'AWS::CloudFormation::Authentication':
+        S3AccessCreds:
+          type: S3
+          accessKeyId: !Ref CfnKeys
+          secretKey: !GetAtt
+            - CfnKeys
+            - SecretAccessKey
+          buckets:
+            - !Ref BucketName
+    Properties:
+      ImageId: !FindInMap [ AWSRegion2AMI, !Ref "AWS::Region", AMI ]
+      {%- if instance_type_ref %}
+      InstanceType: !Ref {{ instance_type_ref }}
+      {% else %}
+      InstanceType: t3.micro
+      {% endif -%}
+      KeyName: !Ref KeyName
+      IamInstanceProfile: !Ref LogRoleInstanceProfile
+      {%- if volume_size %}
+      BlockDeviceMappings:
+        - DeviceName: "/dev/sda1"
+          Ebs:
+            VolumeSize: {{ volume_size }}
+      {%- endif %}
+      Tags:
+        - Key: Name
+          Value: !Join
+              - ':'
+              - - '{{ name }}'
+                - !Ref TestName
+      NetworkInterfaces:
+        - GroupSet:
+            - !Ref InstanceSecurityGroup
+          {%- if public %}
+          AssociatePublicIpAddress: 'true'
+          SubnetId: !Ref PublicSubnet
+          {% else %}
+          AssociatePublicIpAddress: 'false'
+          SubnetId: !Ref PrivateSubnet
+          {% endif -%}
+          DeviceIndex: '0'
+          DeleteOnTermination: 'true'
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash -xe
+          apt-get -y update
+          # Install AWS CloudFormation Helper Scripts
+          apt-get -y install python-pip
+          mkdir aws-cfn-bootstrap-latest
+          curl -s https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz -O
+          pip install aws-cfn-bootstrap-latest.tar.gz
+          tar xzf aws-cfn-bootstrap-latest.tar.gz -C  aws-cfn-bootstrap-latest --strip-components 1
+          ln -s aws-cfn-bootstrap-latest/init/ubuntu/cfn-hup /etc/init.d/cfn-hup
+          # Initialize
+          /usr/local/bin/cfn-init -v --stack ${AWS::StackId} --resource {{ resource_name }} --region ${AWS::Region}
+          # Extract distribution
+          tar -xvf /home/ubuntu/performance-distribution.tar.gz -C /home/ubuntu
+          # Must run setup script in User Data (Commands executed within cfn-init do not show the progress in logs)
+          # Run setup
+          {% if caller is defined -%}
+          {{ caller()|indent(10) }}
+          {% endif -%}
+          # Signal
+          /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource {{ resource_name }} --region ${AWS::Region}
+    CreationPolicy:
+      ResourceSignal:
+        Timeout: PT30M
+{%- endmacro %}
+{% block ec2instances %}
+{% endblock %}
+Outputs:
+{%- block outputs %}
+  StackVPC:
+    Description: The ID of the VPC
+    Value: !Ref VPC
+{%- endblock %}

--- a/distribution/scripts/cloudformation/templates/common_perf_test_cfn.yaml
+++ b/distribution/scripts/cloudformation/templates/common_perf_test_cfn.yaml
@@ -298,7 +298,7 @@ Resources:
   #######################
   # EC2 Instances
   #######################
-{%- macro ec2instance(resource_name, name, instance_type_ref, files=[], public=false, volume_size=None) %}
+{%- macro ec2instance(resource_name, name, instance_type, files=[], public=false, volume_size=None) %}
   {{ resource_name }}:
     Type: 'AWS::EC2::Instance'
     DependsOn: [AttachGateway, BucketPolicy]
@@ -418,7 +418,7 @@ Resources:
             - !Ref BucketName
     Properties:
       ImageId: !FindInMap [ AWSRegion2AMI, !Ref "AWS::Region", AMI ]
-      InstanceType: {{ instance_type_ref }}
+      InstanceType: {{ instance_type }}
       KeyName: !Ref KeyName
       IamInstanceProfile: !Ref LogRoleInstanceProfile
       {%- if volume_size %}

--- a/distribution/scripts/cloudformation/templates/common_perf_test_cfn.yaml
+++ b/distribution/scripts/cloudformation/templates/common_perf_test_cfn.yaml
@@ -358,7 +358,6 @@ Resources:
                   - !Ref BucketName
                   - /
                   - !Ref PerformanceDistributionName
-                  - .pem
               mode: '000664'
               owner: ubuntu
               group: ubuntu
@@ -419,11 +418,7 @@ Resources:
             - !Ref BucketName
     Properties:
       ImageId: !FindInMap [ AWSRegion2AMI, !Ref "AWS::Region", AMI ]
-      {%- if instance_type_ref %}
-      InstanceType: !Ref {{ instance_type_ref }}
-      {% else %}
-      InstanceType: t3.micro
-      {% endif -%}
+      InstanceType: {{ instance_type_ref }}
       KeyName: !Ref KeyName
       IamInstanceProfile: !Ref LogRoleInstanceProfile
       {%- if volume_size %}
@@ -465,9 +460,9 @@ Resources:
           /usr/local/bin/cfn-init -v --stack ${AWS::StackId} --resource {{ resource_name }} --region ${AWS::Region}
           # Extract distribution
           tar xzf /home/ubuntu/performance-distribution.tar.gz -C /home/ubuntu
+          {% if caller is defined -%}
           # Must run setup script in User Data (Commands executed within cfn-init do not show the progress in logs)
           # Run setup
-          {% if caller is defined -%}
           {{ caller()|indent(10) }}
           {% endif -%}
           # Signal
@@ -479,66 +474,7 @@ Resources:
 {% block ec2instances %}
 {% endblock %}
 {% if start_bastian %}
-  BastionInstance:
-    Type: 'AWS::EC2::Instance'
-    Metadata:
-      'AWS::CloudFormation::Init':
-        config:
-          files:
-            /home/ubuntu/performance-distribution.tar.gz:
-              source: !Join
-                - ''
-                - - 'https://s3.'
-                  - !Ref BucketRegion
-                  - '.amazonaws.com/'
-                  - !Ref BucketName
-                  - /
-                  - !Ref PerformanceDistributionName
-                  - .pem
-              mode: '000664'
-              owner: ubuntu
-              group: ubuntu
-              authentication: "S3AccessCreds"
-            /home/ubuntu/private_key.pem:
-              source: !Join
-                - ''
-                - - 'https://s3.'
-                  - !Ref BucketRegion
-                  - '.amazonaws.com/'
-                  - !Ref BucketName
-                  - /
-                  - !Ref KeyName
-                  - .pem
-              mode: '000400'
-              owner: ubuntu
-              group: ubuntu
-              authentication: "S3AccessCreds"
-      'AWS::CloudFormation::Authentication':
-        S3AccessCreds:
-          type: S3
-          accessKeyId: !Ref CfnKeys
-          secretKey: !GetAtt
-            - CfnKeys
-            - SecretAccessKey
-          buckets:
-            - !Ref BucketName
-    Properties:
-      ImageId: !FindInMap [ AWSRegion2AMI, !Ref "AWS::Region", AMI ]
-      InstanceType: t3.nano
-      KeyName: !Ref KeyName
-      Tags:
-        - Key: Name
-          Value: !Join
-              - ':'
-              - - 'bastian'
-                - !Ref TestName
-      NetworkInterfaces:
-        - GroupSet:
-            - !Ref InstanceSecurityGroup
-          AssociatePublicIpAddress: 'true'
-          SubnetId: !Ref PublicSubnet
-          DeviceIndex: '0'
-          DeleteOnTermination: 'true'
+{{ ec2instance('BastionInstance', 'bastian', 't3.nano', public=True) }}
 {% endif -%}
 Outputs:
 {%- block outputs %}

--- a/distribution/scripts/jmeter/perf-test-common.sh
+++ b/distribution/scripts/jmeter/perf-test-common.sh
@@ -351,6 +351,7 @@ function write_server_metrics() {
     $command_prefix sar -q >${report_location}/${server}_loadavg.txt
     $command_prefix sar -A >${report_location}/${server}_sar.txt
     $command_prefix top -bn 1 >${report_location}/${server}_top.txt
+    $command_prefix df -h >${report_location}/${server}_disk_usage.txt
     if [[ ! -z $pgrep_pattern ]]; then
         $command_prefix ps u -p \`pgrep -f $pgrep_pattern\` >${report_location}/${server}_ps.txt
     fi

--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <performance.common.version>0.2.1-SNAPSHOT</performance.common.version>
         <jcommander.version>1.72</jcommander.version>
-        <netty.version>4.1.31.Final</netty.version>
+        <netty.version>4.1.32.Final</netty.version>
         <slf4j.version>1.7.25</slf4j.version>
         <slf4j.version.range>[1.7.0,1.8.0)</slf4j.version.range>
         <log4j.version>2.11.1</log4j.version>


### PR DESCRIPTION
## Purpose
Use a common AWS CloudFormation template

## Goals
Avoid repeating same configurations in multiple places. With template, all common configurations are specified only once.

## Approach
Use Jinja2 template