### PR TITLE
Append a flag to display errors at AWS S3 sync

### DIFF
--- a/distribution/scripts/cloudformation/cloudformation-common.sh
+++ b/distribution/scripts/cloudformation/cloudformation-common.sh
@@ -547,7 +547,7 @@ if function_exists create_links; then
 fi
 
 echo "Syncing files in $temp_dir to S3 Bucket $s3_bucket_name..."
-aws s3 sync --quiet --delete $temp_dir s3://$s3_bucket_name
+aws s3 sync --quiet --delete --only-show-errors $temp_dir s3://$s3_bucket_name
 
 echo "Listing files in S3 Bucket $s3_bucket_name..."
 aws --region $s3_bucket_region s3 ls --summarize s3://$s3_bucket_name


### PR DESCRIPTION
## Purpose
With the use of `--only-show-errors` flag only errors and warnings are displayed. All other output is suppressed. Added this flag in order to identify the causer if there will be an error occurred in the future.

https://docs.aws.amazon.com/cli/latest/reference/s3/sync.html