### PR TITLE
Run netty scripts as non root user

### DIFF
--- a/distribution/scripts/jmeter/perf-test-common.sh
+++ b/distribution/scripts/jmeter/perf-test-common.sh
@@ -549,7 +549,7 @@ function test_scenarios() {
                         if [[ $sleep_time -ge 0 ]]; then
                             local backend_flags="${scenario[backend_flags]}"
                             echo "Starting Backend Service. Delay: $sleep_time, Additional Flags: ${backend_flags:-N/A}"
-                            ssh -t $backend_ssh_host "sudo ./netty-service/netty-start.sh -m $netty_service_heap_size -w \
+                            ssh $backend_ssh_host "./netty-service/netty-start.sh -m $netty_service_heap_size -w \
                                 -- ${backend_flags} --delay $sleep_time"
                             collect_server_metrics netty $backend_ssh_host netty
                         fi

--- a/distribution/scripts/jmeter/run-backend-tests.sh
+++ b/distribution/scripts/jmeter/run-backend-tests.sh
@@ -76,7 +76,7 @@ function before_execute_test_scenario() {
         return 0
     fi
     echo "Restarting Backend Service. Heap: $heap, Delay: $sleep_time, Additional Flags: ${backend_flags:-N/A}"
-    ssh -t $backend_ssh_host "sudo ./netty-service/netty-start.sh -m $heap -w \
+    ssh $backend_ssh_host "./netty-service/netty-start.sh -m $heap -w \
      -- ${backend_flags} --delay $sleep_time"
     collect_server_metrics netty $backend_ssh_host netty
 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Start the netty-script as root, throws a Permission denied error in EI-performance build.

```
[wso2-ei-test-1] [2020-05-25 15:38:27] Report location is /home/ubuntu/results/DirectProxy/1G_heap/100_users/500B/0ms_sleep
[wso2-ei-test-1] [2020-05-25 15:38:27] Starting Backend Service. Delay: 0, Additional Flags: N/A
[wso2-ei-test-1] [2020-05-25 15:38:27] Warning: Permanently added '10.0.1.243' (ECDSA) to the list of known hosts.
[wso2-ei-test-1] [2020-05-25 15:38:27] Starting Netty
[wso2-ei-test-1] [2020-05-25 15:38:27] mkdir: cannot create directory ‘logs’: Permission denied
[wso2-ei-test-1] [2020-05-25 15:38:27] ./netty-service/netty-start.sh: line 81: netty.out: Permission denied
[wso2-ei-test-1] [2020-05-25 15:38:27] Waiting till the port 8688 starts to listen.
[wso2-ei-test-1] [2020-05-25 15:38:27] nc: connect to localhost port 8688 (tcp) failed: Connection refused
```