### PR TITLE
Parameterize max content length

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,9 @@ Usage: EchoHttpServer [options]
     --worker-threads
       Worker Threads
       Default: 8
+    --max-content-length
+      Max HTTP content length in bytes
+      Default: 1048576 (i.e. 1MiB)
 ```
 
 ### Payloads

--- a/components/netty-http-echo-service/src/main/java/org/wso2/performance/common/netty/echo/EchoHttpServer.java
+++ b/components/netty-http-echo-service/src/main/java/org/wso2/performance/common/netty/echo/EchoHttpServer.java
@@ -95,6 +95,9 @@ public final class EchoHttpServer {
     @Parameter(names = "--h2-content-aggregate", description = "Enable HTTP/2 content aggregation")
     private boolean h2ContentAggregate = true;
 
+    @Parameter(names = "--max-content-length", description = "Max HTTP content length in bytes")
+    private int maxContentLength = 1 * 1024 * 1024; // Default 1MiB
+
     public static void main(String[] args) throws Exception {
         EchoHttpServer echoHttpServer = new EchoHttpServer();
         final JCommander jcmdr = new JCommander(echoHttpServer);
@@ -163,7 +166,7 @@ public final class EchoHttpServer {
                             p.addLast(sslCtx.newHandler(ch.alloc()));
                         }
                         p.addLast(new HttpServerCodec());
-                        p.addLast("aggregator", new HttpObjectAggregator(1048576));
+                        p.addLast("aggregator", new HttpObjectAggregator(maxContentLength));
                         p.addLast(new EchoHttpServerHandler(sleepTime, false));
                     }
                 });


### PR DESCRIPTION
## Purpose
Getting HTTP 413 for requests with larger payload size (>1MiB)