### PR TITLE
Upgrade CloudFormation setup to Ubuntu 22.04 with Python 3-compatible bootstrap scripts

### DIFF
--- a/distribution/scripts/cloudformation/cloudformation-common.sh
+++ b/distribution/scripts/cloudformation/cloudformation-common.sh
@@ -602,7 +602,7 @@ trap exit_handler EXIT
 
 # Find latest Ubuntu AMI ID
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/finding-an-ami.html
-latest_ami_id="$(aws ec2 describe-images --owners 099720109477 --filters 'Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????' 'Name=state,Values=available' --output json | jq -r '.Images | sort_by(.CreationDate) | last(.[]).ImageId')"
+latest_ami_id="$(aws ec2 describe-images --owners 099720109477 --filters 'Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????' 'Name=state,Values=available' --output json | jq -r '.Images | sort_by(.CreationDate) | last(.[]).ImageId')"
 echo "Latest Ubuntu AMI ID: $latest_ami_id"
 
 # Create stacks

--- a/distribution/scripts/cloudformation/cloudformation-common.sh
+++ b/distribution/scripts/cloudformation/cloudformation-common.sh
@@ -602,7 +602,7 @@ trap exit_handler EXIT
 
 # Find latest Ubuntu AMI ID
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/finding-an-ami.html
-latest_ami_id="$(aws ec2 describe-images --owners 099720109477 --filters 'Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????' 'Name=state,Values=available' --output json | jq -r '.Images | sort_by(.CreationDate) | last(.[]).ImageId')"
+latest_ami_id="$(aws ec2 describe-images --owners 099720109477 --filters 'Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????' 'Name=state,Values=available' --output json | jq -r '.Images | sort_by(.CreationDate) | .[-1].ImageId')"
 echo "Latest Ubuntu AMI ID: $latest_ami_id"
 
 # Create stacks

--- a/distribution/scripts/cloudformation/cloudformation-common.sh
+++ b/distribution/scripts/cloudformation/cloudformation-common.sh
@@ -602,7 +602,7 @@ trap exit_handler EXIT
 
 # Find latest Ubuntu AMI ID
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/finding-an-ami.html
-latest_ami_id="$(aws ec2 describe-images --owners 099720109477 --filters 'Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????' 'Name=state,Values=available' --output json | jq -r '.Images | sort_by(.CreationDate) | .[-1].ImageId')"
+latest_ami_id="$(aws ec2 describe-images --owners 099720109477 --filters 'Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-????????' 'Name=state,Values=available' --output json | jq -r '.Images | sort_by(.CreationDate) | .[-1].ImageId')"
 echo "Latest Ubuntu AMI ID: $latest_ami_id"
 
 # Create stacks

--- a/distribution/scripts/cloudformation/templates/common_perf_test_cfn.yaml
+++ b/distribution/scripts/cloudformation/templates/common_perf_test_cfn.yaml
@@ -464,33 +464,44 @@ Resources:
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash -xe
-          echo "running server hostname: "`hostname`
-          echo "running server public ip: "`curl ifconfig.me`
-          echo "running server /etc/hosts: "`cat /etc/hosts`
+          echo "running server hostname: $(hostname)"
+          echo "running server public ip: $(curl -s ifconfig.me)"
+          echo "running server /etc/hosts: $(cat /etc/hosts)"
+
           export DEBIAN_FRONTEND=noninteractive
+
+          # Update and install required packages
           apt-get update
-          # Install required packages
-          apt-get -y -q -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install python-pip jq zip unzip
+          apt-get -y -q -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install python3-pip jq zip unzip
+
           # Install AWS CloudFormation Helper Scripts
-          mkdir aws-cfn-bootstrap-latest
-          curl -s https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz -O
-          pip install aws-cfn-bootstrap-latest.tar.gz
-          tar xzf aws-cfn-bootstrap-latest.tar.gz -C aws-cfn-bootstrap-latest --strip-components 1
-          ln -s aws-cfn-bootstrap-latest/init/ubuntu/cfn-hup /etc/init.d/cfn-hup
+          cd /tmp
+          curl -s https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz -O
+          pip3 install aws-cfn-bootstrap-py3-latest.tar.gz --upgrade
+
+          # Extract bootstrap scripts for cfn-hup
+          mkdir -p /home/ubuntu/aws-cfn-bootstrap-latest
+          tar xzf aws-cfn-bootstrap-py3-latest.tar.gz -C /home/ubuntu/aws-cfn-bootstrap-latest --strip-components 1
+          ln -sf /home/ubuntu/aws-cfn-bootstrap-latest/init/ubuntu/cfn-hup /etc/init.d/cfn-hup
+
           # Initialize
-          /usr/local/bin/cfn-init -v --stack ${AWS::StackId} --resource {{ resource_name }} --region ${AWS::Region}
+          cfn-init -v --stack ${AWS::StackId} --resource {{ resource_name }} --region ${AWS::Region}
+
           # Extract distribution
           tar xzf /home/ubuntu/performance-distribution.tar.gz -C /home/ubuntu
+
           {% if caller is defined -%}
           # Must run setup script in User Data (Commands executed within cfn-init do not show the progress in logs)
           # Run setup
           {{ caller()|indent(10) }}
           {% endif -%}
+
           # Write system information
           mkdir /home/ubuntu/system-info
           /home/ubuntu/cloudformation/write-system-information.sh -o /home/ubuntu/system-info/
-          # Signal
-          /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource {{ resource_name }} --region ${AWS::Region}
+
+          # Signal CloudFormation that setup is complete
+          cfn-signal -e $? --stack ${AWS::StackId} --resource {{ resource_name }} --region ${AWS::Region}
     CreationPolicy:
       ResourceSignal:
         Timeout: PT30M


### PR DESCRIPTION
## Purpose

This pull request updates the CloudFormation setup scripts to use Ubuntu 22.04 (Jammy) and modernizes the bootstrap and package installation steps for compatibility with Python 3. The changes improve reliability and future-proof the provisioning process.

* Updated the AMI filter in `cloudformation-common.sh` to use Ubuntu 22.04 (Jammy) instead of Ubuntu 18.04 (Bionic).
* Changed package installation in the CloudFormation template to use `python3-pip` instead of the deprecated `python-pip`.
* Switched to the Python 3-compatible AWS CloudFormation bootstrap scripts (`aws-cfn-bootstrap-py3-latest.tar.gz`), and updated all related installation and extraction commands to use `pip3` and new paths.
* Updated the extraction and symlinking of `cfn-hup` to use the new bootstrap location, ensuring proper initialization on Ubuntu 22.04.
* Replaced calls to `/usr/local/bin/cfn-init` and `/usr/local/bin/cfn-signal` with `cfn-init` and `cfn-signal` to match the new bootstrap installation and maintain consistency.


